### PR TITLE
Update rn_updated_at time, after result generation

### DIFF
--- a/rra-analysis/app/index.js
+++ b/rra-analysis/app/index.js
@@ -156,6 +156,21 @@ operationExecutor
 
   logger.log('Done writing result CSVs');
 })
+// Update generation time.
+// Since it's a JSON field we need to fetch it and update it.
+.then(() => db.transaction(function (trx) {
+  return trx('scenarios')
+    .select('*')
+    .where('id', scId)
+    .first()
+    .then(scenario => {
+      let data = scenario.data;
+      data.res_gen_at = (new Date());
+      return trx('scenarios')
+        .update({ data })
+        .where('id', scId);
+    });
+}))
 .then(() => operation.log(opCodes.OP_RESULTS_FILES, {message: 'Files written'}))
 .then(() => operation.log(opCodes.OP_SUCCESS, {message: 'Operation complete'}))
 .then(() => operation.finish())


### PR DESCRIPTION
Related to https://github.com/WorldBank-Transport/Rural-Road-Accessibility/issues/97.

To display a message to the user when the results are outdated, we need to know the last time they were generated.
This value will then be compared with the last time the road network was updated, and we'll know whether the results are outdated or not.